### PR TITLE
Image2 and other

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,41 +1,38 @@
-#Installation
-* Download the ckeditor library.
-* Enable this module and dependencies.
-* Copy the ckeditor.config.js as directed below.
+# sb_wysiwyg
+
+A starter Drupal WYSIWYG feature module, intended to get common rich text editor functionality installed and configured quickly for any Drupal 7 site.
+
+Includes:
+
+* CKEditor with the Enhanced Image plugin
+* IMCE file browser, configured for links and images and to allow directory creation
+* CKEditor Link module for better internal Drupal links
+* Better Formats to simplify the textareas where Ckeditor is used
+
+# Installation
+
+Run the quick install via drush make from your Drupal directory:
+
+    $ drush make --no-core https://gist.githubusercontent.com/jeffam/dfed5a54d91c54bcbd3f/raw
+
+Enable the module:
+
+    $ drush en sb_wysiwyg -y
+
+Customize for your site:
+
 * Configure permissions and user roles for ckeditor and IMCE profiles.
 * Configure permissions and settings for better formats.
 * Customized settings further for the specific site use and update this feature.
 
-#Maintenance
-Bug reports, improvements and additions should be contributed to the repo as
-pull requests. https://github.com/singlebrook/sb_wysiwyg
+# Customizing ckeditor
 
-## The ckeditor library
-This module expects ckeditor to come with certain plugins. Use the link below
-to download the latest version of ckeditor in the configuration we like.
+## ckeditor.styles.js
 
-The library should go in /sites/all/libraries/ckeditor.
-
-Here's the direct download link: http://ckeditor.com/builder/download/74728b9f070da5aec655a9daa246cb23
-See http://ckeditor.com/builder/74728b9f070da5aec655a9daa246cb23 for details.
-
-
-## Notes about dependencies
-better_formats To simplify the textareas where Ckeditor is used.
-
-ckeditor The library integration module for drupal. This does not use the wysiwyg module.
-
-ckeditor_link Adds options to search and link internal content.
-
-imce Provides file browser and uploading.
-
-imce_mkdir Allows users to create new directories with IMCE.
-
-## Customizing ckeditor
-###ckeditor.styles.js
 This file lives in the feature directory. Use it to add to the styles dropdown.
 
-###ckeditor.config.js
+## ckeditor.config.js
+
 Copy this file from the ckeditor module directory to the default theme folder.
 You can use this to add any config customizations. If you're using empty tags,
 here is an example:
@@ -46,18 +43,22 @@ here is an example:
   CKEDITOR.dtd.$removeEmpty.span = 0;
 ```
 
-##Custom CSS
-In ```css/ckeditor_contents.css``` you can add custom css to load into the editor.
+## Custom CSS
 
+In `css/ckeditor_contents.css` you can add custom css to load into the editor.
 
-##IMCE
+# IMCE
+
 The default template is overridden to allow larger images to show and to
 use the experimental box / icon display of files rather than the list.
 
-##Font icons module
+# Font icons module
+
 Used on the Pathways site, the font icons module (a socialfield sub module) loads fonts and css for icons
 from fontello.com. If used, this feature will load the css into the editor
 so the font icons appear. Consider this an example of how to load custom css from
 a library or contrib module into the editor.
 
+# Contribution
 
+Bug reports, improvements, and additions are welcome via pull request!

--- a/readme.md
+++ b/readme.md
@@ -52,13 +52,6 @@ In `css/ckeditor_contents.css` you can add custom css to load into the editor.
 The default template is overridden to allow larger images to show and to
 use the experimental box / icon display of files rather than the list.
 
-# Font icons module
-
-Used on the Pathways site, the font icons module (a socialfield sub module) loads fonts and css for icons
-from fontello.com. If used, this feature will load the css into the editor
-so the font icons appear. Consider this an example of how to load custom css from
-a library or contrib module into the editor.
-
 # Contribution
 
 Bug reports, improvements, and additions are welcome via pull request!

--- a/sb_wysiwyg.features.ckeditor_profile.inc
+++ b/sb_wysiwyg.features.ckeditor_profile.inc
@@ -55,7 +55,7 @@ function sb_wysiwyg_ckeditor_profile_defaults() {
         'html_entities' => 'f',
         'scayt_autoStartup' => 'f',
         'theme_config_js' => 't',
-        'js_conf' => 'config.image2_alignClasses = [ \'media-left\', \'center-block\', \'media-right\' ];',
+        'js_conf' => 'config.image2_alignClasses = [ \'pull-left\', \'center-block\', \'pull-right\' ];',
         'loadPlugins' => array(
           'ckeditor_link' => array(
             'name' => 'drupal_path',
@@ -167,7 +167,7 @@ function sb_wysiwyg_ckeditor_profile_defaults() {
         'html_entities' => 'f',
         'scayt_autoStartup' => 'f',
         'theme_config_js' => 't',
-        'js_conf' => 'config.image2_alignClasses = [ \'media-left\', \'center-block\', \'media-right\' ];',
+        'js_conf' => 'config.image2_alignClasses = [ \'pull-left\', \'center-block\', \'pull-right\' ];',
         'loadPlugins' => array(
           'ckeditor_link' => array(
             'name' => 'drupal_path',

--- a/sb_wysiwyg.features.ckeditor_profile.inc
+++ b/sb_wysiwyg.features.ckeditor_profile.inc
@@ -83,7 +83,7 @@ function sb_wysiwyg_ckeditor_profile_defaults() {
         'html_entities' => 'f',
         'scayt_autoStartup' => 'f',
         'theme_config_js' => 't',
-        'js_conf' => '',
+        'js_conf' => 'config.image2_alignClasses = [ \'media-left\', \'center-block\', \'media-right\' ];',
         'loadPlugins' => array(
           'ckeditor_link' => array(
             'name' => 'drupal_path',

--- a/sb_wysiwyg.features.ckeditor_profile.inc
+++ b/sb_wysiwyg.features.ckeditor_profile.inc
@@ -9,6 +9,90 @@
  */
 function sb_wysiwyg_ckeditor_profile_defaults() {
   $data = array(
+    'Advanced' => array(
+      'name' => 'Advanced',
+      'settings' => array(
+        'ss' => 2,
+        'toolbar' => '[
+    [\'Bold\',\'Italic\',\'RemoveFormat\',\'Format\',\'-\',\'NumberedList\',\'BulletedList\',\'SpecialChar\',\'-\',\'Link\',\'Unlink\',\'Image\',\'HorizontalRule\',\'Anchor\'],
+    [\'Source\']
+]',
+        'expand' => 't',
+        'default' => 't',
+        'show_toggle' => 't',
+        'uicolor' => 'default',
+        'uicolor_user' => '#056805',
+        'width' => '100%',
+        'lang' => 'en',
+        'auto_lang' => 't',
+        'language_direction' => 'default',
+        'allowed_content' => 'f',
+        'extraAllowedContent' => '',
+        'enter_mode' => 'p',
+        'shift_enter_mode' => 'br',
+        'font_format' => 'p;pre;h2;h3;h4;h5;h6',
+        'custom_formatting' => 'f',
+        'formatting' => array(
+          'custom_formatting_options' => array(
+            'indent' => 'indent',
+            'breakBeforeOpen' => 'breakBeforeOpen',
+            'breakAfterClose' => 'breakAfterClose',
+            'pre_indent' => 'pre_indent',
+            'breakAfterOpen' => 0,
+            'breakBeforeClose' => 0,
+          ),
+        ),
+        'css_mode' => 'none',
+        'css_path' => '',
+        'css_style' => 'self',
+        'styles_path' => '',
+        'filebrowser' => 'imce',
+        'filebrowser_image' => 'imce',
+        'filebrowser_flash' => 'imce',
+        'UserFilesPath' => '%b%f/',
+        'UserFilesAbsolutePath' => '%d%b%f/',
+        'forcePasteAsPlainText' => 't',
+        'html_entities' => 'f',
+        'scayt_autoStartup' => 'f',
+        'theme_config_js' => 't',
+        'js_conf' => 'config.image2_alignClasses = [ \'media-left\', \'center-block\', \'media-right\' ];',
+        'loadPlugins' => array(
+          'ckeditor_link' => array(
+            'name' => 'drupal_path',
+            'desc' => 'CKEditor Link - A plugin to easily create links to Drupal internal paths',
+            'path' => '%base_path%sites/all/modules/contrib/ckeditor_link/plugins/link/',
+            'buttons' => FALSE,
+          ),
+          'drupalbreaks' => array(
+            'name' => 'drupalbreaks',
+            'desc' => 'Plugin for inserting Drupal teaser and page breaks.',
+            'path' => '%plugin_dir%drupalbreaks/',
+            'buttons' => array(
+              'DrupalBreak' => array(
+                'label' => 'DrupalBreak',
+                'icon' => 'images/drupalbreak.png',
+              ),
+            ),
+            'default' => 't',
+          ),
+          'mediaembed' => array(
+            'name' => 'mediaembed',
+            'desc' => 'Plugin for inserting Drupal embeded media',
+            'path' => '%plugin_dir%mediaembed/',
+            'buttons' => array(
+              'MediaEmbed' => array(
+                'label' => 'MediaEmbed',
+                'icon' => 'images/icon.png',
+              ),
+            ),
+            'default' => 'f',
+          ),
+        ),
+      ),
+      'input_formats' => array(
+        'filtered_html' => 'Filtered HTML',
+      ),
+    ),
     'CKEditor Global Profile' => array(
       'name' => 'CKEditor Global Profile',
       'settings' => array(

--- a/sb_wysiwyg.features.filter.inc
+++ b/sb_wysiwyg.features.filter.inc
@@ -22,7 +22,7 @@ function sb_wysiwyg_filter_default_formats() {
         'weight' => -48,
         'status' => 1,
         'settings' => array(
-          'allowed_html' => '<h2> <h3> <h4> <h5> <h6> <em> <strong> <pre> <code> <del> <img> <blockquote> <q> <cite> <sup> <sub> <p> <span> <br> <ul> <ol> <li> <dl> <dt> <dd> <a> <b> <u> <i> <!-->',
+          'allowed_html' => '<h2> <h3> <h4> <h5> <h6> <em> <strong> <pre> <code> <del> <img> <blockquote> <q> <cite> <sup> <sub> <p> <span> <br> <ul> <ol> <li> <dl> <dt> <dd> <a> <b> <u> <i> <!--> <figure> <figcaption>',
           'filter_html_help' => 1,
           'filter_html_nofollow' => 0,
         ),

--- a/sb_wysiwyg.features.filter.inc
+++ b/sb_wysiwyg.features.filter.inc
@@ -49,6 +49,19 @@ function sb_wysiwyg_filter_default_formats() {
           'filter_url_length' => 72,
         ),
       ),
+      'image_resize_filter' => array(
+        'weight' => 0,
+        'status' => 1,
+        'settings' => array(
+          'link' => 0,
+          'link_class' => '',
+          'link_rel' => '',
+          'image_locations' => array(
+            'local' => 'local',
+            'remote' => 0,
+          ),
+        ),
+      ),
     ),
   );
 
@@ -75,6 +88,19 @@ function sb_wysiwyg_filter_default_formats() {
         'status' => 1,
         'settings' => array(
           'filter_url_length' => 72,
+        ),
+      ),
+      'image_resize_filter' => array(
+        'weight' => 0,
+        'status' => 1,
+        'settings' => array(
+          'link' => 0,
+          'link_class' => '',
+          'link_rel' => '',
+          'image_locations' => array(
+            'local' => 'local',
+            'remote' => 0,
+          ),
         ),
       ),
       'filter_htmlcorrector' => array(

--- a/sb_wysiwyg.info
+++ b/sb_wysiwyg.info
@@ -10,6 +10,7 @@ dependencies[] = ckeditor_link
 dependencies[] = ctools
 dependencies[] = features
 dependencies[] = filter
+dependencies[] = image_resize_filter
 dependencies[] = imce
 dependencies[] = imce_mkdir
 dependencies[] = strongarm

--- a/sb_wysiwyg.info
+++ b/sb_wysiwyg.info
@@ -13,6 +13,7 @@ dependencies[] = filter
 dependencies[] = imce
 dependencies[] = imce_mkdir
 dependencies[] = strongarm
+features[ckeditor_profile][] = Advanced
 features[ckeditor_profile][] = CKEditor Global Profile
 features[ckeditor_profile][] = Full
 features[ctools][] = strongarm:strongarm:1

--- a/sb_wysiwyg.make
+++ b/sb_wysiwyg.make
@@ -1,0 +1,19 @@
+core = 7.x
+api = 2
+
+defaults[projects][subdir] = "contrib"
+
+projects[] = better_formats
+projects[] = ckeditor
+projects[] = ckeditor_link
+projects[] = ctools
+projects[] = features
+projects[] = imce
+projects[] = imce_mkdir
+projects[] = strongarm
+
+; View this configuration at http://ckeditor.com/builder/f12a07768c695a71a99404902ce54f1b
+libraries[ckeditor][download][type] = "get"
+libraries[ckeditor][download][url] = "http://ckeditor.com/builder/download/f12a07768c695a71a99404902ce54f1b"
+libraries[ckeditor][directory_name] = "ckeditor"
+libraries[ckeditor][destination] = "libraries"

--- a/sb_wysiwyg.make
+++ b/sb_wysiwyg.make
@@ -8,6 +8,7 @@ projects[] = ckeditor
 projects[] = ckeditor_link
 projects[] = ctools
 projects[] = features
+projects[] = image_resize_filter
 projects[] = imce
 projects[] = imce_mkdir
 projects[] = strongarm

--- a/sb_wysiwyg.module
+++ b/sb_wysiwyg.module
@@ -29,12 +29,4 @@ function sb_wysiwyg_ckeditor_settings_alter(&$settings, $conf) {
 
   // Add a custom css file for editing styles.
   $settings['contentsCss'][] = '/' . drupal_get_path('module', 'sb_wysiwyg') . '/css/ckeditor_contents.css';
-
-  // If using font icons module (for social field) load the font icons css.
-  if (module_exists('font_icons')) {
-    $font = font_icons_libraries_info();
-    foreach ($font as $name => $library) {
-      $settings['contentsCss'][] = '/sites/all/libraries/' . $name . '/' . $library['files']['css'][0];
-    }
-  }
 }


### PR DESCRIPTION
This pull request is a bit large, but it's just easier to add this all at once. Here's what it does:
- Adds a make file for easier installation. The new way to install is via a `drush make` one liner that'll get this module, its deps, and the ckeditor js library. (This will only work when this code is merged into master.)
- Updates the ckeditor config to include the image2 (Enhanced Image) plugin.
- Sets image2 to use classes instead of inline styles (e.g. class="media-left" vs. style="float: left"). Those should be bootstrap compatible classes.
- Adds and configures the advanced ckeditor profile, since installing that module adds it anyway.
- Removes the font_icons custom module stuff.
- Updates the readme.
- Enables world peace.
